### PR TITLE
Move mergeRecordStats in printStats an indentation up

### DIFF
--- a/TESDumpStats.py
+++ b/TESDumpStats.py
@@ -471,19 +471,19 @@ def printStats(stats, outDir, opts):
         mode = 'w'
     allstats = dict()
     for plugin in stats:
+        pstats = stats[plugin]
+        recStats = pstats['records']
         if opts.split:
             outName = os.path.join(outDir, plugin+'.txt')
         with open(outName, mode) as outFile:
             print(plugin, file=outFile)
-            pstats = stats[plugin]
             print(' File Size:', formatSize(pstats['size']), file=outFile)
             print(' File Date:',
                   datetime.datetime.fromtimestamp(pstats['time']),
                   file=outFile)
             print(' File CRC: 0x%X' % pstats['crc'], file=outFile)
-            recStats = pstats['records']
             printRecordStats(recStats, outFile)
-            mergeRecordStats(allstats, recStats)
+        mergeRecordStats(allstats, recStats)
     if len(stats) > 1:
         if opts.split:
             outName = os.path.join(outDir, 'combined_stats.txt')


### PR DESCRIPTION
This leads to two minor improvements:
1) The helper variables are listed in the same place, which makes relevant code be more together:
   - The assignments are next to each other.
   - The `print()` calls under the `with open()` are listed together.
2) `mergeRecordStats` should be called for every iteration of the `for plugin` loop; moving it out of the `with open()` should make this ever so slightly more robust.